### PR TITLE
Fix typo in group cards: Vizualisation -> Visualization

### DIFF
--- a/groups.yaml
+++ b/groups.yaml
@@ -20,7 +20,7 @@
     - cython
     - numba
     - cupy
-- name: Vizualisation
+- name: Visualization
   cmap: winter
   shape: hex
   items:


### PR DESCRIPTION
Found a typo in one of the groups. I think the two possibilities are Visualization (American) or Visualisation (British) but didn't find  Vizualisation. I might be wrong though @Carreau, what do you think? 

You do have "Visualizations" in the matplotlib and bokeh cards.  